### PR TITLE
Use default bucket acl rather than predefined

### DIFF
--- a/api-tests/api-tests-casper.js
+++ b/api-tests/api-tests-casper.js
@@ -636,7 +636,7 @@ casper.test.begin('Connecting to ' + url, function suite(test) {
 
   function checkPublicReadPermission(filename, passfail, attemptNumber) {
     var uri = casper.getHTML("#bucketPath") + "/o/" + filename;
-    var curl = require("child_process").spawn("curl", uri);
+    var curl;
 
     if (attemptNumber === undefined) {attemptNumber = 0;}
     attemptNumber += 1;
@@ -650,6 +650,7 @@ casper.test.begin('Connecting to ' + url, function suite(test) {
     function repetitivePermissionCheck(attemptNumber) {
       console.log("permission check number " + attemptNumber);
       console.log("uri:" + uri);
+      curl = require("child_process").spawn("curl", uri);
       curl.stdout.on("data", function(data) {
         var jsonResponse = JSON.parse(data);
         console.log("public read result: " + JSON.stringify(jsonResponse));

--- a/src/main/java/com/risevision/storage/Globals.java
+++ b/src/main/java/com/risevision/storage/Globals.java
@@ -33,7 +33,7 @@ public final class Globals {
                       + "</Logging>";
 
   public static final String RESUMABLE_UPLOAD_REQUEST_URI =
-    "https://www.googleapis.com/upload/storage/v1/b/myBucket/o?uploadType=resumable&predefinedAcl=publicRead&name=";
+    "https://www.googleapis.com/upload/storage/v1/b/myBucket/o?uploadType=resumable&name=";
 
   public static final String DELETED_NAMESPACE =
     "-deleted-";


### PR DESCRIPTION
@fjvallarino This relies on the default bucket ACLs (which are now all set in prod).

Note that the code you wrote for restoring from trash currently sets the ACL back using a predefined ACL.  That's not a major problem, but it would be better to set it back to the predefined ACL.   See createBucket in StorageService for the setAcl() call.