### PR TITLE
Use p12 signer for downloads

### DIFF
--- a/src/main/java/com/risevision/storage/gcs/AppEngineCredentialSignedURIGenerator.java
+++ b/src/main/java/com/risevision/storage/gcs/AppEngineCredentialSignedURIGenerator.java
@@ -7,11 +7,11 @@ import org.apache.commons.codec.binary.Base64;
 
 import com.google.appengine.api.appidentity.*;
 
-public class SignedURIGenerator {
+public class AppEngineCredentialSignedURIGenerator {
   private static final AppIdentityService identityService = 
   AppIdentityServiceFactory.getAppIdentityService();
   
-  private SignedURIGenerator() {}
+  private AppEngineCredentialSignedURIGenerator() {}
   
   public static String getSignedURI
   (String verb, String bucketName, String objectName)

--- a/src/main/java/com/risevision/storage/gcs/P12SignedURIGenerator.java
+++ b/src/main/java/com/risevision/storage/gcs/P12SignedURIGenerator.java
@@ -10,12 +10,12 @@ import org.apache.commons.codec.binary.Base64;
 
 import com.risevision.storage.Globals;
 
-public class LocalSignedURIGenerator {
+public class P12SignedURIGenerator {
   private static PrivateKey key;
   
   static {
     try {
-      key = loadKeyFromPkcs12(Globals.RVCORE_P12_PATH, "notasecret".toCharArray());
+      key = loadKeyFromPkcs12(Globals.RVMEDIA_P12_PATH, "notasecret".toCharArray());
     }
     catch (Exception e) {
       e.printStackTrace();
@@ -24,7 +24,7 @@ public class LocalSignedURIGenerator {
     
   }
   
-  private LocalSignedURIGenerator() {}
+  private P12SignedURIGenerator() {}
   
   public static String getSignedURI(String verb, String bucketName, String objectName) throws Exception {
     return generateSigningURL(verb, bucketName, objectName);
@@ -34,7 +34,7 @@ public class LocalSignedURIGenerator {
     long expiration = getExpiration();
     String url_signature = signString(verb + "\n\n\n" + expiration + "\n" + "/" + bucketName + "/" + objectName);
     String signed_url = "https://storage.googleapis.com/" + bucketName + "/"
-        + objectName + "?GoogleAccessId=" + Globals.RVCORE_ID
+        + objectName + "?GoogleAccessId=" + Globals.RVMEDIA_ID
         + "&Expires=" + expiration + "&Signature="
         + URLEncoder.encode(url_signature, "UTF-8");
     return signed_url;

--- a/src/main/java/com/risevision/storage/gcs/StorageService.java
+++ b/src/main/java/com/risevision/storage/gcs/StorageService.java
@@ -342,12 +342,7 @@ public final class StorageService {
     String signedURI;
     
     try {
-      if(Globals.devserver) {
-        signedURI = LocalSignedURIGenerator.getSignedURI("GET", bucketId, fileName);
-      }
-      else {
-        signedURI = SignedURIGenerator.getSignedURI("GET", bucketId, fileName);
-      }
+      signedURI = P12SignedURIGenerator.getSignedURI("GET", bucketId, fileName);
     } catch (Exception e) {
       log.warning(e.getMessage());
       throw new ServiceFailedException(ServiceFailedException.SERVER_ERROR);


### PR DESCRIPTION
@fjvallarino The signed download was using the app engine identity instead of the P12 file signer.  I renamed the classes (eg P12Signer instead of LocalSigner) and updated the signing process sothat it uses the correct global variable.  Please review.