### PR TITLE
Begin using query to store baseline numbers

### DIFF
--- a/src/test/java/unit/com/risevision/storage/servertasks/UpdateThrottleBaselineTest.java
+++ b/src/test/java/unit/com/risevision/storage/servertasks/UpdateThrottleBaselineTest.java
@@ -83,7 +83,9 @@ public class UpdateThrottleBaselineTest {
     UpdateThrottleBaselineServerTask task = new UpdateThrottleBaselineServerTask
     (null, null, bqRequestor);
 
-    task.handleRequest();
+    task.getDataFromBQ();
+    task.calculateMeanAndSD();
+    task.saveMeanAndSD();
 
     assertThat("it saved the mean", 
     OfyService.ofy().load().type(ThrottleBaseline.class).order("-date").limit(1).first().now().getMean(),


### PR DESCRIPTION
Add datastore persistence

Move test/java/* test/java/unit/*

Use integration test for response requestor
Unit tests use the mock query requestor.  The integration test confirms
that the live query requestor also works.

Update build process
We don't need to mvn install - package is fine.
This will run the unit tests but not the integration tests since they
shouldn't need to be run as often.

Use exponential backoff retry

Use more efficient array handling
Stop processing rows when 60% have been processed.
Don't use a separate array for doubles

Force task queue